### PR TITLE
#52 Delete category endpoint

### DIFF
--- a/Api/ShoppingList.Api.Client/IShoppingListApiClient.cs
+++ b/Api/ShoppingList.Api.Client/IShoppingListApiClient.cs
@@ -1,4 +1,5 @@
 ﻿using ProjectHermes.ShoppingList.Api.Contracts.Common.Queries;
+using ProjectHermes.ShoppingList.Api.Contracts.ItemCategory.Commands;
 using ProjectHermes.ShoppingList.Api.Contracts.ItemCategory.Queries.AllActiveItemCategories;
 using ProjectHermes.ShoppingList.Api.Contracts.Manufacturer.Queries.AllActiveManufacturers;
 using ProjectHermes.ShoppingList.Api.Contracts.ShoppingList.Commands.AddItemToShoppingList;
@@ -132,6 +133,9 @@ namespace ProjectHermes.ShoppingList.Api.Client
 
         [Post("item-category/create/{name}")]
         Task CreateItemCategory([Path] string name);
+
+        [Post("item-category/delete")]
+        Task DeleteItemCategory([Body] DeleteItemCategoryContract contract);
 
         #endregion ItemCategoryController
     }

--- a/Api/ShoppingList.Api.Client/ShoppingListApiClient.cs
+++ b/Api/ShoppingList.Api.Client/ShoppingListApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using ProjectHermes.ShoppingList.Api.Contracts.Common.Queries;
+using ProjectHermes.ShoppingList.Api.Contracts.ItemCategory.Commands;
 using ProjectHermes.ShoppingList.Api.Contracts.ItemCategory.Queries.AllActiveItemCategories;
 using ProjectHermes.ShoppingList.Api.Contracts.Manufacturer.Queries.AllActiveManufacturers;
 using ProjectHermes.ShoppingList.Api.Contracts.ShoppingList.Commands.AddItemToShoppingList;
@@ -207,6 +208,11 @@ namespace ProjectHermes.ShoppingList.Api.Client
         public async Task CreateItemCategory(string name)
         {
             await apiClient.CreateItemCategory(name);
+        }
+
+        public async Task DeleteItemCategory([Body] DeleteItemCategoryContract contract)
+        {
+            await apiClient.DeleteItemCategory(contract);
         }
 
         #endregion ItemCategoryController

--- a/Api/ShoppingList.Api.Contracts/ItemCategory/Commands/DeleteItemCategoryContract.cs
+++ b/Api/ShoppingList.Api.Contracts/ItemCategory/Commands/DeleteItemCategoryContract.cs
@@ -1,0 +1,7 @@
+﻿namespace ProjectHermes.ShoppingList.Api.Contracts.ItemCategory.Commands
+{
+    public class DeleteItemCategoryContract
+    {
+        public int ItemCategoryId { get; set; }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ItemCategoryRepositoryMockExtensions.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ItemCategoryRepositoryMockExtensions.cs
@@ -17,5 +17,14 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(returnValue));
         }
+
+        public static void VerifyStoreAsyncOnce(this Mock<IItemCategoryRepository> mock, IItemCategory itemCategory)
+        {
+            mock.
+                Verify(i => i.StoreAsync(
+                    It.Is<IItemCategory>(cat => cat == itemCategory),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
     }
 }

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ItemRepositoryMockExtensions.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ItemRepositoryMockExtensions.cs
@@ -29,5 +29,23 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(returnValue);
         }
+
+        public static void VerifyStoreAsyncOnce(this Mock<IItemRepository> mock, IStoreItem storeItem)
+        {
+            mock.Verify(
+                i => i.StoreAsync(
+                    It.Is<IStoreItem>(item => item == storeItem),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        public static void VerifyStoreAsyncNever(this Mock<IItemRepository> mock)
+        {
+            mock.Verify(
+                i => i.StoreAsync(
+                    It.IsAny<IStoreItem>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
     }
 }

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ItemRepositoryMockExtensions.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ItemRepositoryMockExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using Moq;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
 using ProjectHermes.ShoppingList.Api.Domain.Common.Ports;
 using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,6 +18,16 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions
                     It.Is<StoreItemId>(id => id == storeItemId),
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(returnValue));
+        }
+
+        public static void SetupFindActiveByAsync(this Mock<IItemRepository> mock, ItemCategoryId itemCategoryId,
+            IEnumerable<IStoreItem> returnValue)
+        {
+            mock
+                .Setup(i => i.FindActiveByAsync(
+                    It.Is<ItemCategoryId>(id => id == itemCategoryId),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(returnValue);
         }
     }
 }

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ShoppingListRepositoryMockExtensions.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ShoppingListRepositoryMockExtensions.cs
@@ -50,5 +50,23 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions
                     It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<IShoppingList>(returnValue));
         }
+
+        public static void VerifyStoreAsyncOnce(this Mock<IShoppingListRepository> mock, IShoppingList shoppingList)
+        {
+            mock.Verify(
+                i => i.StoreAsync(
+                    It.Is<IShoppingList>(list => list == shoppingList),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        public static void VerifyStoreAsyncNever(this Mock<IShoppingListRepository> mock)
+        {
+            mock.Verify(
+                i => i.StoreAsync(
+                    It.IsAny<IShoppingList>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
     }
 }

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ShoppingListRepositoryMockExtensions.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/ShoppingListRepositoryMockExtensions.cs
@@ -21,6 +21,16 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions
                 .Returns(Task.FromResult(returnValue));
         }
 
+        public static void SetupFindActiveByAsync(this Mock<IShoppingListRepository> mock,
+            IEnumerable<IShoppingList> returnValue)
+        {
+            mock
+                .Setup(i => i.FindActiveByAsync(
+                    It.IsAny<StoreItemId>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(returnValue);
+        }
+
         public static void SetupFindActiveByAsync(this Mock<IShoppingListRepository> mock, StoreId storeId,
             IShoppingList returnValue)
         {

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/TransactionMockExtensions.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Extensions/TransactionMockExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Moq;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Ports.Infrastructure;
+using System.Threading;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions
+{
+    public static class TransactionMockExtensions
+    {
+        public static void VerifyCommitAsyncOnce(this Mock<ITransaction> mock)
+        {
+            mock.Verify(
+                i => i.CommitAsync(
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/ItemCategoryFixture.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/ItemCategoryFixture.cs
@@ -1,0 +1,30 @@
+﻿using AutoFixture;
+using ProjectHermes.ShoppingList.Api.Core.Tests.AutoFixture;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures
+{
+    public class ItemCategoryFixture
+    {
+        private readonly CommonFixture commonFixture;
+
+        public ItemCategoryFixture(CommonFixture commonFixture)
+        {
+            this.commonFixture = commonFixture;
+        }
+
+        public IItemCategory GetItemCategory(ItemCategoryId id = null, string name = null, bool? isDeleted = null)
+        {
+            var fixture = commonFixture.GetNewFixture();
+
+            if (id != null)
+                fixture.ConstructorArgumentFor<ItemCategory, ItemCategoryId>("id", id);
+            if (name != null)
+                fixture.ConstructorArgumentFor<ItemCategory, string>("name", name);
+            if (isDeleted.HasValue)
+                fixture.ConstructorArgumentFor<ItemCategory, bool>("isDeleted", isDeleted.Value);
+
+            return fixture.Create<ItemCategory>();
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/ItemCategoryMockFixture.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/ItemCategoryMockFixture.cs
@@ -1,0 +1,35 @@
+﻿using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
+using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures
+{
+    public class ItemCategoryMockFixture
+    {
+        private readonly CommonFixture commonFixture;
+        private readonly ItemCategoryFixture itemCategoryFixture;
+
+        public ItemCategoryMockFixture(CommonFixture commonFixture, ItemCategoryFixture itemCategoryFixture)
+        {
+            this.commonFixture = commonFixture;
+            this.itemCategoryFixture = itemCategoryFixture;
+        }
+
+        public ItemCategoryMock Create()
+        {
+            return CreateMany(1).First();
+        }
+
+        public IEnumerable<ItemCategoryMock> CreateMany(int amount)
+        {
+            var uniqueIds = commonFixture.NextUniqueInts(amount);
+
+            foreach (var id in uniqueIds)
+            {
+                var itemCategory = itemCategoryFixture.GetItemCategory(new ItemCategoryId(id));
+                yield return new ItemCategoryMock(itemCategory);
+            }
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/ShoppingListMockFixture.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/ShoppingListMockFixture.cs
@@ -1,0 +1,35 @@
+﻿using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Models;
+using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures
+{
+    public class ShoppingListMockFixture
+    {
+        private readonly CommonFixture commonFixture;
+        private readonly ShoppingListFixture shoppingListFixture;
+
+        public ShoppingListMockFixture(CommonFixture commonFixture, ShoppingListFixture shoppingListFixture)
+        {
+            this.commonFixture = commonFixture;
+            this.shoppingListFixture = shoppingListFixture;
+        }
+
+        public ShoppingListMock Create()
+        {
+            return CreateMany(1).First();
+        }
+
+        public IEnumerable<ShoppingListMock> CreateMany(int amount)
+        {
+            var uniqueIds = commonFixture.NextUniqueInts(amount);
+
+            foreach (var id in uniqueIds)
+            {
+                var shoppingList = shoppingListFixture.GetShoppingList(new ShoppingListId(id));
+                yield return new ShoppingListMock(shoppingList);
+            }
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/StoreItemFixture.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/StoreItemFixture.cs
@@ -40,7 +40,20 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures
             return fixture.Create<StoreItem>();
         }
 
-        private IEnumerable<IStoreItemAvailability> GetUniqueStoreItemAvailabilities(int count, IEnumerable<int> exclude)
+        public IEnumerable<IStoreItem> GetStoreItems(int amount = 3, int availabilityCount = 3,
+            bool? isTemporary = null, bool? isDeleted = null)
+        {
+            var ids = commonFixture.NextUniqueInts(amount).ToList();
+
+            foreach (var id in ids)
+            {
+                yield return GetStoreItem(new StoreItemId(id), availabilityCount: availabilityCount,
+                    isTemporary: isTemporary, isDeleted: isDeleted);
+            }
+        }
+
+        private IEnumerable<IStoreItemAvailability> GetUniqueStoreItemAvailabilities(int count,
+            IEnumerable<int> exclude = null)
         {
             List<int> storeIds = commonFixture.NextUniqueInts(count, exclude).ToList();
             List<IStoreItemAvailability> availabilities = new List<IStoreItemAvailability>();

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/StoreItemMockFixture.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Fixtures/StoreItemMockFixture.cs
@@ -1,0 +1,35 @@
+﻿using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models;
+using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures
+{
+    public class StoreItemMockFixture
+    {
+        private readonly CommonFixture commonFixture;
+        private readonly StoreItemFixture storeItemFixture;
+
+        public StoreItemMockFixture(CommonFixture commonFixture, StoreItemFixture storeItemFixture)
+        {
+            this.commonFixture = commonFixture;
+            this.storeItemFixture = storeItemFixture;
+        }
+
+        public StoreItemMock Create()
+        {
+            return CreateMany(1).First();
+        }
+
+        public IEnumerable<StoreItemMock> CreateMany(int amount)
+        {
+            var uniqueIds = commonFixture.NextUniqueInts(amount);
+
+            foreach (var id in uniqueIds)
+            {
+                var storeItem = storeItemFixture.GetStoreItem(new StoreItemId(id));
+                yield return new StoreItemMock(storeItem);
+            }
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/ItemCategoryMock.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/ItemCategoryMock.cs
@@ -1,0 +1,24 @@
+﻿using Moq;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks
+{
+    public class ItemCategoryMock : Mock<IItemCategory>
+    {
+        public ItemCategoryMock(IItemCategory itemCategory)
+        {
+            SetupId(itemCategory.Id);
+        }
+
+        public void SetupId(ItemCategoryId returnValue)
+        {
+            Setup(i => i.Id)
+                .Returns(returnValue);
+        }
+
+        public void VerifyDeleteOnce()
+        {
+            Verify(i => i.Delete(), Times.Once);
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/ShoppingListMock.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/ShoppingListMock.cs
@@ -7,6 +7,7 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks
     {
         public ShoppingListMock(IShoppingList shoppingList)
         {
+            SetupId(shoppingList.Id);
         }
 
         public void SetupId(ShoppingListId returnValue)

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/ShoppingListMock.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/ShoppingListMock.cs
@@ -1,0 +1,25 @@
+﻿using Moq;
+using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Models;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks
+{
+    public class ShoppingListMock : Mock<IShoppingList>
+    {
+        public ShoppingListMock(IShoppingList shoppingList)
+        {
+        }
+
+        public void SetupId(ShoppingListId returnValue)
+        {
+            Setup(i => i.Id)
+                .Returns(returnValue);
+        }
+
+        public void VerifyRemoveItemOnce(ShoppingListItemId itemId)
+        {
+            Verify(i => i.RemoveItem(
+                    It.Is<ShoppingListItemId>(id => id == itemId)),
+                Times.Once);
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/StoreItemMock.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/Common/Mocks/StoreItemMock.cs
@@ -1,0 +1,24 @@
+﻿using Moq;
+using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks
+{
+    public class StoreItemMock : Mock<IStoreItem>
+    {
+        public StoreItemMock(IStoreItem storeItem)
+        {
+            SetupId(storeItem.Id);
+        }
+
+        public void SetupId(StoreItemId returnValue)
+        {
+            Setup(i => i.Id)
+            .Returns(returnValue);
+        }
+
+        public void VerifyDeleteOnce()
+        {
+            Verify(i => i.Delete(), Times.Once);
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandlerTests.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandlerTests.cs
@@ -13,6 +13,7 @@ using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Ports;
 using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models;
 using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions;
 using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures;
+using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,6 +29,8 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.ItemCategories.Commands.De
         private readonly ShoppingListFixture shoppingListFixture;
         private readonly StoreItemFixture storeItemFixture;
         private readonly ItemCategoryFixture itemCategoryFixture;
+        private readonly StoreItemMockFixture storeItemMockFixture;
+        private readonly ShoppingListMockFixture shoppingListMockFixture;
 
         public DeleteItemCategoryCommandHandlerTests()
         {
@@ -37,6 +40,8 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.ItemCategories.Commands.De
             var storeItemAvailabilityFixture = new StoreItemAvailabilityFixture(commonFixture);
             storeItemFixture = new StoreItemFixture(storeItemAvailabilityFixture, commonFixture);
             itemCategoryFixture = new ItemCategoryFixture(commonFixture);
+            storeItemMockFixture = new StoreItemMockFixture(commonFixture, storeItemFixture);
+            shoppingListMockFixture = new ShoppingListMockFixture(commonFixture, shoppingListFixture);
         }
 
         [Fact]
@@ -189,6 +194,82 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.ItemCategories.Commands.De
                             It.Is<IStoreItem>(item => item == storeItemMock.Object),
                             It.IsAny<CancellationToken>()),
                         Times.Once);
+                }
+
+                itemCategoryRepositoryMock.Verify(
+                    i => i.StoreAsync(
+                        It.Is<IItemCategory>(cat => cat == itemCategory),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+
+                transactionMock.Verify(
+                    i => i.CommitAsync(
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithSomeItemsOfItemCategoryOnActiveShoppingLists_ShouldStoreItemsAndShoppingListsAndDeleteItemCategory()
+        {
+            // Arrange
+            var fixture = commonFixture.GetNewFixture();
+
+            Mock<IItemCategoryRepository> itemCategoryRepositoryMock = fixture.Freeze<Mock<IItemCategoryRepository>>();
+            Mock<IItemRepository> itemRepositoryMock = fixture.Freeze<Mock<IItemRepository>>();
+            Mock<IShoppingListRepository> shoppingListRepositoryMock = fixture.Freeze<Mock<IShoppingListRepository>>();
+            Mock<ITransactionGenerator> transactionGeneratorMock = fixture.Freeze<Mock<ITransactionGenerator>>();
+
+            IItemCategory itemCategory = itemCategoryFixture.GetItemCategory(isDeleted: false);
+            var storeItemMocks = storeItemMockFixture.CreateMany(2).ToList();
+            var shoppingLists = new Dictionary<StoreItemMock, List<ShoppingListMock>>();
+            foreach (var storeItemMock in storeItemMocks)
+            {
+                int amount = commonFixture.NextInt(1, 5);
+                var listMocks = shoppingListMockFixture.CreateMany(amount).ToList();
+                shoppingLists.Add(storeItemMock, listMocks);
+
+                shoppingListRepositoryMock.SetupFindActiveByAsync(storeItemMock.Object.Id,
+                    listMocks.Select(m => m.Object));
+            }
+
+            Mock<ITransaction> transactionMock = new Mock<ITransaction>();
+
+            var command = fixture.Create<DeleteItemCategoryCommand>();
+            var handler = fixture.Create<DeleteItemCategoryCommandHandler>();
+
+            itemCategoryRepositoryMock.SetupFindByAsync(command.ItemCategoryId, itemCategory);
+            itemRepositoryMock.SetupFindActiveByAsync(command.ItemCategoryId, storeItemMocks.Select(m => m.Object));
+            transactionGeneratorMock.SetupGenerateAsync(transactionMock.Object);
+
+            // Act
+            var result = await handler.HandleAsync(command, default);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Should().BeTrue();
+                itemCategory.IsDeleted.Should().BeTrue();
+
+                foreach (var storeItemMock in storeItemMocks)
+                {
+                    storeItemMock.VerifyDeleteOnce();
+
+                    itemRepositoryMock.Verify(
+                        i => i.StoreAsync(
+                            It.Is<IStoreItem>(item => item == storeItemMock.Object),
+                            It.IsAny<CancellationToken>()),
+                        Times.Once);
+
+                    IEnumerable<ShoppingListMock> affiliatedShoppinListMocks = shoppingLists[storeItemMock];
+                    foreach (var listMock in affiliatedShoppinListMocks)
+                    {
+                        shoppingListRepositoryMock.Verify(
+                            i => i.StoreAsync(
+                                It.Is<IShoppingList>(l => l == listMock.Object),
+                                It.IsAny<CancellationToken>()),
+                            Times.Once);
+                    }
                 }
 
                 itemCategoryRepositoryMock.Verify(

--- a/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandlerTests.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandlerTests.cs
@@ -11,6 +11,7 @@ using ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.DeleteItemCa
 using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Models;
 using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Ports;
 using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models;
+using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models.Extensions;
 using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions;
 using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures;
 using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Mocks;
@@ -264,6 +265,8 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Tests.ItemCategories.Commands.De
                     IEnumerable<ShoppingListMock> affiliatedShoppinListMocks = shoppingLists[storeItemMock];
                     foreach (var listMock in affiliatedShoppinListMocks)
                     {
+                        listMock.VerifyRemoveItemOnce(storeItemMock.Object.Id.ToShoppingListItemId());
+
                         shoppingListRepositoryMock.Verify(
                             i => i.StoreAsync(
                                 It.Is<IShoppingList>(l => l == listMock.Object),

--- a/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandlerTests.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandlerTests.cs
@@ -1,0 +1,199 @@
+﻿using AutoFixture;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Moq;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Exceptions;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Exceptions.Reason;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Ports;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Ports.Infrastructure;
+using ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.DeleteItemCategory;
+using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Models;
+using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Ports;
+using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models;
+using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Extensions;
+using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.ItemCategories.Commands.DeleteItemCategory
+{
+    public class DeleteItemCategoryCommandHandlerTests
+    {
+        private readonly CommonFixture commonFixture;
+        private readonly ShoppingListFixture shoppingListFixture;
+        private readonly StoreItemFixture storeItemFixture;
+        private readonly ItemCategoryFixture itemCategoryFixture;
+
+        public DeleteItemCategoryCommandHandlerTests()
+        {
+            commonFixture = new CommonFixture();
+            var shoppingListItemFixture = new ShoppingListItemFixture(commonFixture);
+            shoppingListFixture = new ShoppingListFixture(shoppingListItemFixture, commonFixture);
+            var storeItemAvailabilityFixture = new StoreItemAvailabilityFixture(commonFixture);
+            storeItemFixture = new StoreItemFixture(storeItemAvailabilityFixture, commonFixture);
+            itemCategoryFixture = new ItemCategoryFixture(commonFixture);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithCommandIsNull_ShouldThrowArgumentNullException()
+        {
+            // Arrange
+            var fixture = commonFixture.GetNewFixture();
+            var handler = fixture.Create<DeleteItemCategoryCommandHandler>();
+
+            // Act
+            Func<Task<bool>> action = async () => await handler.HandleAsync(null, default);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                await action.Should().ThrowAsync<ArgumentNullException>();
+            }
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithInvalidItemCategoryId_ShouldThrowDomainException()
+        {
+            // Arrange
+            var fixture = commonFixture.GetNewFixture();
+
+            Mock<IItemCategoryRepository> itemCategoryRepositoryMock = fixture.Freeze<Mock<IItemCategoryRepository>>();
+
+            var command = fixture.Create<DeleteItemCategoryCommand>();
+            var handler = fixture.Create<DeleteItemCategoryCommandHandler>();
+
+            itemCategoryRepositoryMock.SetupFindByAsync(command.ItemCategoryId, null);
+
+            // Act
+            Func<Task<bool>> action = async () => await handler.HandleAsync(command, default);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                (await action.Should().ThrowAsync<DomainException>())
+                    .Where(e => e.Reason.ErrorCode == ErrorReasonCode.ItemCategoryNotFound);
+            }
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithNoItemsOfItemCategory_ShouldNotStoreAnyItemsAndDeleteItemCategory()
+        {
+            // Arrange
+            var fixture = commonFixture.GetNewFixture();
+
+            Mock<IItemCategoryRepository> itemCategoryRepositoryMock = fixture.Freeze<Mock<IItemCategoryRepository>>();
+            Mock<IItemRepository> itemRepositoryMock = fixture.Freeze<Mock<IItemRepository>>();
+            Mock<IShoppingListRepository> shoppingListRepositoryMock = fixture.Freeze<Mock<IShoppingListRepository>>();
+            Mock<ITransactionGenerator> transactionGeneratorMock = fixture.Freeze<Mock<ITransactionGenerator>>();
+
+            IItemCategory itemCategory = itemCategoryFixture.GetItemCategory(isDeleted: false);
+            Mock<ITransaction> transactionMock = new Mock<ITransaction>();
+
+            var command = fixture.Create<DeleteItemCategoryCommand>();
+            var handler = fixture.Create<DeleteItemCategoryCommandHandler>();
+
+            itemCategoryRepositoryMock.SetupFindByAsync(command.ItemCategoryId, itemCategory);
+            itemRepositoryMock.SetupFindActiveByAsync(command.ItemCategoryId, Enumerable.Empty<IStoreItem>());
+            transactionGeneratorMock.SetupGenerateAsync(transactionMock.Object);
+
+            // Act
+            var result = await handler.HandleAsync(command, default);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Should().BeTrue();
+                itemCategory.IsDeleted.Should().BeTrue();
+
+                shoppingListRepositoryMock.Verify(
+                    i => i.StoreAsync(
+                        It.IsAny<IShoppingList>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+
+                itemRepositoryMock.Verify(
+                    i => i.StoreAsync(
+                        It.IsAny<IStoreItem>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+
+                itemCategoryRepositoryMock.Verify(
+                    i => i.StoreAsync(
+                        It.Is<IItemCategory>(cat => cat == itemCategory),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+
+                transactionMock.Verify(
+                    i => i.CommitAsync(
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithSomeItemsOfItemCategoryOnNoActiveShoppingLists_ShouldStoreItemsButNoShoppingListsAndDeleteItemCategory()
+        {
+            // Arrange
+            int storeItemsCount = 3;
+            var fixture = commonFixture.GetNewFixture();
+
+            Mock<IItemCategoryRepository> itemCategoryRepositoryMock = fixture.Freeze<Mock<IItemCategoryRepository>>();
+            Mock<IItemRepository> itemRepositoryMock = fixture.Freeze<Mock<IItemRepository>>();
+            Mock<IShoppingListRepository> shoppingListRepositoryMock = fixture.Freeze<Mock<IShoppingListRepository>>();
+            Mock<ITransactionGenerator> transactionGeneratorMock = fixture.Freeze<Mock<ITransactionGenerator>>();
+
+            IItemCategory itemCategory = itemCategoryFixture.GetItemCategory(isDeleted: false);
+            List<IStoreItem> storeItems = storeItemFixture.GetStoreItems(storeItemsCount, isDeleted: false).ToList();
+            Mock<ITransaction> transactionMock = new Mock<ITransaction>();
+
+            var command = fixture.Create<DeleteItemCategoryCommand>();
+            var handler = fixture.Create<DeleteItemCategoryCommandHandler>();
+
+            itemCategoryRepositoryMock.SetupFindByAsync(command.ItemCategoryId, itemCategory);
+            itemRepositoryMock.SetupFindActiveByAsync(command.ItemCategoryId, storeItems);
+            shoppingListRepositoryMock.SetupFindActiveByAsync(Enumerable.Empty<IShoppingList>());
+            transactionGeneratorMock.SetupGenerateAsync(transactionMock.Object);
+
+            // Act
+            var result = await handler.HandleAsync(command, default);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Should().BeTrue();
+                itemCategory.IsDeleted.Should().BeTrue();
+
+                shoppingListRepositoryMock.Verify(
+                    i => i.StoreAsync(
+                        It.IsAny<IShoppingList>(),
+                        It.IsAny<CancellationToken>()),
+                    Times.Never);
+
+                foreach (var storeItem in storeItems)
+                {
+                    itemRepositoryMock.Verify(
+                        i => i.StoreAsync(
+                            It.Is<IStoreItem>(item => item == storeItem),
+                            It.IsAny<CancellationToken>()),
+                        Times.Once);
+                }
+
+                itemCategoryRepositoryMock.Verify(
+                    i => i.StoreAsync(
+                        It.Is<IItemCategory>(cat => cat == itemCategory),
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+
+                transactionMock.Verify(
+                    i => i.CommitAsync(
+                        It.IsAny<CancellationToken>()),
+                    Times.Once);
+            }
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Models/ItemCategoryTests.cs
+++ b/Api/ShoppingList.Api.Domain.Tests/ItemCategories/Models/ItemCategoryTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using ProjectHermes.ShoppingList.Api.Domain.Tests.Common.Fixtures;
+using Xunit;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.Tests.ItemCategories.Models
+{
+    public class ItemCategoryTests
+    {
+        private readonly CommonFixture commonFixture;
+        private readonly ItemCategoryFixture itemCategoryFixture;
+
+        public ItemCategoryTests()
+        {
+            commonFixture = new CommonFixture();
+            itemCategoryFixture = new ItemCategoryFixture(commonFixture);
+        }
+
+        [Fact]
+        public void Delete_WithValidData_ShouldMarkItemCategoryAsDeleted()
+        {
+            // Arrange
+            var itemCategory = itemCategoryFixture.GetItemCategory(isDeleted: false);
+
+            // Act
+            itemCategory.Delete();
+
+            // Assert
+            using (new AssertionScope())
+            {
+                itemCategory.IsDeleted.Should().BeTrue();
+            }
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain/Common/Models/IItemCategory.cs
+++ b/Api/ShoppingList.Api.Domain/Common/Models/IItemCategory.cs
@@ -5,5 +5,7 @@
         ItemCategoryId Id { get; }
         string Name { get; }
         bool IsDeleted { get; }
+
+        void Delete();
     }
 }

--- a/Api/ShoppingList.Api.Domain/Common/Models/ItemCategory.cs
+++ b/Api/ShoppingList.Api.Domain/Common/Models/ItemCategory.cs
@@ -11,6 +11,11 @@
 
         public ItemCategoryId Id { get; }
         public string Name { get; }
-        public bool IsDeleted { get; }
+        public bool IsDeleted { get; set; }
+
+        public void Delete()
+        {
+            IsDeleted = true;
+        }
     }
 }

--- a/Api/ShoppingList.Api.Domain/Common/Ports/IItemCategoryRepository.cs
+++ b/Api/ShoppingList.Api.Domain/Common/Ports/IItemCategoryRepository.cs
@@ -13,7 +13,7 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Common.Ports
 
         Task<IEnumerable<IItemCategory>> FindByAsync(IEnumerable<ItemCategoryId> ids, CancellationToken cancellationToken);
 
-        Task<IEnumerable<IItemCategory>> FindByAsync(bool includeDeleted, CancellationToken cancellationToken);
+        Task<IEnumerable<IItemCategory>> FindActiveByAsync(CancellationToken cancellationToken);
 
         Task<IItemCategory> StoreAsync(IItemCategory model, CancellationToken cancellationToken);
     }

--- a/Api/ShoppingList.Api.Domain/Common/Ports/IItemRepository.cs
+++ b/Api/ShoppingList.Api.Domain/Common/Ports/IItemRepository.cs
@@ -21,5 +21,6 @@ namespace ProjectHermes.ShoppingList.Api.Domain.Common.Ports
         Task<IEnumerable<IStoreItem>> FindActiveByAsync(string searchInput, StoreId storeId, CancellationToken cancellationToken);
 
         Task<IStoreItem> StoreAsync(IStoreItem storeItem, CancellationToken cancellationToken);
+        Task<IEnumerable<IStoreItem>> FindActiveByAsync(ItemCategoryId itemCategoryId, CancellationToken cancellationToken);
     }
 }

--- a/Api/ShoppingList.Api.Domain/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommand.cs
+++ b/Api/ShoppingList.Api.Domain/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommand.cs
@@ -1,0 +1,15 @@
+﻿using ProjectHermes.ShoppingList.Api.Domain.Common.Commands;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.DeleteItemCategory
+{
+    public class DeleteItemCategoryCommand : ICommand<bool>
+    {
+        public DeleteItemCategoryCommand(ItemCategoryId itemCategoryId)
+        {
+            ItemCategoryId = itemCategoryId;
+        }
+
+        public ItemCategoryId ItemCategoryId { get; }
+    }
+}

--- a/Api/ShoppingList.Api.Domain/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandler.cs
+++ b/Api/ShoppingList.Api.Domain/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandler.cs
@@ -3,6 +3,8 @@ using ProjectHermes.ShoppingList.Api.Domain.Common.Exceptions;
 using ProjectHermes.ShoppingList.Api.Domain.Common.Exceptions.Reason;
 using ProjectHermes.ShoppingList.Api.Domain.Common.Ports;
 using ProjectHermes.ShoppingList.Api.Domain.Common.Ports.Infrastructure;
+using ProjectHermes.ShoppingList.Api.Domain.ShoppingLists.Ports;
+using ProjectHermes.ShoppingList.Api.Domain.StoreItems.Models.Extensions;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,13 +15,16 @@ namespace ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.DeleteIt
     {
         private readonly IItemCategoryRepository itemCategoryRepository;
         private readonly IItemRepository itemRepository;
+        private readonly IShoppingListRepository shoppingListRepository;
         private readonly ITransactionGenerator transactionGenerator;
 
         public DeleteItemCategoryCommandHandler(IItemCategoryRepository itemCategoryRepository,
-            IItemRepository itemRepository, ITransactionGenerator transactionGenerator)
+            IItemRepository itemRepository, IShoppingListRepository shoppingListRepository,
+            ITransactionGenerator transactionGenerator)
         {
             this.itemCategoryRepository = itemCategoryRepository;
             this.itemRepository = itemRepository;
+            this.shoppingListRepository = shoppingListRepository;
             this.transactionGenerator = transactionGenerator;
         }
 
@@ -40,12 +45,18 @@ namespace ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.DeleteIt
                 .ToList();
 
             using var transaction = await transactionGenerator.GenerateAsync(cancellationToken);
-            await itemCategoryRepository.StoreAsync(category, cancellationToken);
             foreach (var item in storeItems)
             {
+                var lists = await shoppingListRepository.FindActiveByAsync(item.Id, cancellationToken);
+                foreach (var list in lists)
+                {
+                    list.RemoveItem(item.Id.ToShoppingListItemId());
+                    await shoppingListRepository.StoreAsync(list, cancellationToken);
+                }
                 item.Delete();
                 await itemRepository.StoreAsync(item, cancellationToken);
             }
+            await itemCategoryRepository.StoreAsync(category, cancellationToken);
 
             await transaction.CommitAsync(cancellationToken);
             return true;

--- a/Api/ShoppingList.Api.Domain/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandler.cs
+++ b/Api/ShoppingList.Api.Domain/ItemCategories/Commands/DeleteItemCategory/DeleteItemCategoryCommandHandler.cs
@@ -1,0 +1,54 @@
+﻿using ProjectHermes.ShoppingList.Api.Domain.Common.Commands;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Exceptions;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Exceptions.Reason;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Ports;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Ports.Infrastructure;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.DeleteItemCategory
+{
+    public class DeleteItemCategoryCommandHandler : ICommandHandler<DeleteItemCategoryCommand, bool>
+    {
+        private readonly IItemCategoryRepository itemCategoryRepository;
+        private readonly IItemRepository itemRepository;
+        private readonly ITransactionGenerator transactionGenerator;
+
+        public DeleteItemCategoryCommandHandler(IItemCategoryRepository itemCategoryRepository,
+            IItemRepository itemRepository, ITransactionGenerator transactionGenerator)
+        {
+            this.itemCategoryRepository = itemCategoryRepository;
+            this.itemRepository = itemRepository;
+            this.transactionGenerator = transactionGenerator;
+        }
+
+        public async Task<bool> HandleAsync(DeleteItemCategoryCommand command, CancellationToken cancellationToken)
+        {
+            if (command is null)
+            {
+                throw new System.ArgumentNullException(nameof(command));
+            }
+
+            var category = await itemCategoryRepository.FindByAsync(command.ItemCategoryId, cancellationToken);
+            if (category == null)
+                throw new DomainException(new ItemCategoryNotFoundReason(command.ItemCategoryId));
+
+            category.Delete();
+
+            var storeItems = (await itemRepository.FindActiveByAsync(command.ItemCategoryId, cancellationToken))
+                .ToList();
+
+            using var transaction = await transactionGenerator.GenerateAsync(cancellationToken);
+            await itemCategoryRepository.StoreAsync(category, cancellationToken);
+            foreach (var item in storeItems)
+            {
+                item.Delete();
+                await itemRepository.StoreAsync(item, cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+            return true;
+        }
+    }
+}

--- a/Api/ShoppingList.Api.Domain/ItemCategories/Queries/AllActiveItemCategories/AllActiveItemCategoriesQueryHandler.cs
+++ b/Api/ShoppingList.Api.Domain/ItemCategories/Queries/AllActiveItemCategories/AllActiveItemCategoriesQueryHandler.cs
@@ -27,7 +27,7 @@ namespace ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Queries.AllActive
                 throw new ArgumentNullException(nameof(query));
             }
 
-            var results = await itemCategoryRepository.FindByAsync(false, cancellationToken);
+            var results = await itemCategoryRepository.FindActiveByAsync(cancellationToken);
 
             return results.Select(r => r.ToReadModel());
         }

--- a/Api/ShoppingList.Api.Endpoint/v1/Controllers/ItemCategoryController.cs
+++ b/Api/ShoppingList.Api.Endpoint/v1/Controllers/ItemCategoryController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using ProjectHermes.ShoppingList.Api.Contracts.ItemCategory.Commands;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Exceptions;
 using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
 using ProjectHermes.ShoppingList.Api.Domain.Common.Ports.Infrastructure;
 using ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.CreateItemCategory;
@@ -69,11 +70,19 @@ namespace ProjectHermes.ShoppingList.Api.Endpoint.v1.Controllers
 
         [HttpPost]
         [ProducesResponseType(200)]
+        [ProducesResponseType(400)]
         [Route("delete")]
         public async Task<IActionResult> DeleteItemCategory([FromBody] DeleteItemCategoryContract contract)
         {
             var command = new DeleteItemCategoryCommand(new ItemCategoryId(contract.ItemCategoryId));
-            await commandDispatcher.DispatchAsync(command, default);
+            try
+            {
+                await commandDispatcher.DispatchAsync(command, default);
+            }
+            catch (DomainException e)
+            {
+                return BadRequest(e.Reason);
+            }
 
             return Ok();
         }

--- a/Api/ShoppingList.Api.Endpoint/v1/Controllers/ItemCategoryController.cs
+++ b/Api/ShoppingList.Api.Endpoint/v1/Controllers/ItemCategoryController.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using ProjectHermes.ShoppingList.Api.Contracts.ItemCategory.Commands;
+using ProjectHermes.ShoppingList.Api.Domain.Common.Models;
 using ProjectHermes.ShoppingList.Api.Domain.Common.Ports.Infrastructure;
 using ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.CreateItemCategory;
+using ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Commands.DeleteItemCategory;
 using ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Queries.AllActiveItemCategories;
 using ProjectHermes.ShoppingList.Api.Domain.ItemCategories.Queries.ItemCategorySearch;
 using ProjectHermes.ShoppingList.Api.Endpoint.Extensions.ItemCategory;
@@ -54,11 +57,22 @@ namespace ProjectHermes.ShoppingList.Api.Endpoint.v1.Controllers
         }
 
         [HttpPost]
-        [ProducesResponseType(500)]
+        [ProducesResponseType(200)]
         [Route("create/{name}")]
         public async Task<IActionResult> CreateItemCategory([FromRoute(Name = "name")] string name)
         {
             var command = new CreateItemCategoryCommand(name);
+            await commandDispatcher.DispatchAsync(command, default);
+
+            return Ok();
+        }
+
+        [HttpPost]
+        [ProducesResponseType(200)]
+        [Route("delete")]
+        public async Task<IActionResult> DeleteItemCategory([FromBody] DeleteItemCategoryContract contract)
+        {
+            var command = new DeleteItemCategoryCommand(new ItemCategoryId(contract.ItemCategoryId));
             await commandDispatcher.DispatchAsync(command, default);
 
             return Ok();

--- a/Api/ShoppingList.Api.Infrastructure/Adapters/ItemCategoryRepository.cs
+++ b/Api/ShoppingList.Api.Infrastructure/Adapters/ItemCategoryRepository.cs
@@ -70,11 +70,10 @@ namespace ProjectHermes.ShoppingList.Api.Infrastructure.Adapters
             return entities.Select(e => e.ToDomain());
         }
 
-        public async Task<IEnumerable<IItemCategory>> FindByAsync(bool includeDeleted,
-            CancellationToken cancellationToken)
+        public async Task<IEnumerable<IItemCategory>> FindActiveByAsync(CancellationToken cancellationToken)
         {
             var results = await dbContext.ItemCategories.AsNoTracking()
-                .Where(m => !m.Deleted || includeDeleted)
+                .Where(m => !m.Deleted)
                 .ToListAsync();
 
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
Creates an endpoint for marking an item category as deleted. All items with that category are marked as deleted and removed from any active shopping list (but not from already finished ones).