### PR TITLE
#392: Fix manufacturer in item editor cleared after selection

### DIFF
--- a/Frontend/ShoppingList.Frontend.Redux/Items/Effects/ManufacturerSelectorEffects.cs
+++ b/Frontend/ShoppingList.Frontend.Redux/Items/Effects/ManufacturerSelectorEffects.cs
@@ -97,7 +97,7 @@ public sealed class ManufacturerSelectorEffects : IDisposable
     [EffectMethod(typeof(ManufacturerDropdownClosedAction))]
     public static Task HandleManufacturerDropdownClosedAction(IDispatcher dispatcher)
     {
-        dispatcher.Dispatch(new ClearManufacturerAction());
+        dispatcher.Dispatch(new ManufacturerInputChangedAction(string.Empty));
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
closes #392 