### PR TITLE
#426: Fix missing trailing zero for price in item editor

### DIFF
--- a/Frontend/ShoppingList.Frontend.WebApp/Components/Items/Editor/Availability.razor
+++ b/Frontend/ShoppingList.Frontend.WebApp/Components/Items/Editor/Availability.razor
@@ -70,7 +70,7 @@
 
     private string FormatPriceInput(float price)
     {
-        return $"{price:0.##} {State.Value.Editor.Item!.QuantityType.PriceLabel}";
+        return $"{price:0.00} {State.Value.Editor.Item!.QuantityType.PriceLabel}";
     }
 
     private string ParsePriceInput(string value)


### PR DESCRIPTION
closes #426 