### PR TITLE
#428: Clear store data after modifying/creating/deleting a store

### DIFF
--- a/Frontend/ShoppingList.Frontend.Redux.Tests/Items/Reducers/ItemReducerTests.cs
+++ b/Frontend/ShoppingList.Frontend.Redux.Tests/Items/Reducers/ItemReducerTests.cs
@@ -13,12 +13,7 @@ public class ItemReducerTests
 {
     public class OnSearchItemStarted
     {
-        private readonly OnSearchItemStartedFixture _fixture;
-
-        public OnSearchItemStarted()
-        {
-            _fixture = new OnSearchItemStartedFixture();
-        }
+        private readonly OnSearchItemStartedFixture _fixture = new();
 
         [Fact]
         public void OnSearchItemStarted_WithSearchNotLoading_ShouldSetLoading()
@@ -87,15 +82,10 @@ public class ItemReducerTests
 
     public class OnSearchItemFinished
     {
-        private readonly OnSearchItemFinishedFixture _fixture;
-
-        public OnSearchItemFinished()
-        {
-            _fixture = new OnSearchItemFinishedFixture();
-        }
+        private readonly OnSearchItemFinishedFixture _fixture = new();
 
         [Fact]
-        public void OnSearchItemFinished_WithSearchNotLoading_ShouldSetLoadingAndSortResults()
+        public void OnSearchItemFinished_WithSearchNotLoading_ShouldSetNotLoadingAndSortResults()
         {
             // Arrange
             _fixture.SetupExpectedSearchLoading();
@@ -112,7 +102,7 @@ public class ItemReducerTests
         }
 
         [Fact]
-        public void OnSearchItemFinished_WithSearchLoading_ShouldSetLoadingAndSortResults()
+        public void OnSearchItemFinished_WithSearchLoading_ShouldSetNotLoadingAndSortResults()
         {
             // Arrange
             _fixture.SetupExpectedSearchLoading();
@@ -188,12 +178,7 @@ public class ItemReducerTests
 
     public class OnLoadQuantityTypesFinished
     {
-        private readonly OnLoadQuantityTypesFinishedFixture _fixture;
-
-        public OnLoadQuantityTypesFinished()
-        {
-            _fixture = new OnLoadQuantityTypesFinishedFixture();
-        }
+        private readonly OnLoadQuantityTypesFinishedFixture _fixture = new();
 
         [Fact]
         public void OnLoadQuantityTypesFinished_WithValidData_ShouldSetQuantityTypes()
@@ -232,12 +217,7 @@ public class ItemReducerTests
 
     public class OnLoadQuantityTypesInPacketFinished
     {
-        private readonly OnLoadQuantityTypesInPacketFinishedFixture _fixture;
-
-        public OnLoadQuantityTypesInPacketFinished()
-        {
-            _fixture = new OnLoadQuantityTypesInPacketFinishedFixture();
-        }
+        private readonly OnLoadQuantityTypesInPacketFinishedFixture _fixture = new();
 
         [Fact]
         public void OnLoadQuantityTypesInPacketFinished_WithValidData_ShouldSetQuantityTypesInPacket()
@@ -276,12 +256,7 @@ public class ItemReducerTests
 
     public class OnLoadActiveStoresFinished
     {
-        private readonly OnLoadActiveStoresFinishedFixture _fixture;
-
-        public OnLoadActiveStoresFinished()
-        {
-            _fixture = new OnLoadActiveStoresFinishedFixture();
-        }
+        private readonly OnLoadActiveStoresFinishedFixture _fixture = new();
 
         [Fact]
         public void OnLoadActiveStoresFinished_WithValidData_ShouldSetStores()
@@ -314,6 +289,88 @@ public class ItemReducerTests
             public void SetupAction()
             {
                 Action = new LoadActiveStoresFinishedAction(ExpectedState.Stores);
+            }
+        }
+    }
+
+    public class OnSaveStoreFinished
+    {
+        private readonly OnSaveStoreFinishedFixture _fixture = new();
+
+        [Fact]
+        public void OnSaveStoreFinished_WithValidData_ShouldClearStores()
+        {
+            // Arrange
+            _fixture.SetupInitialState();
+            _fixture.SetupExpectedState();
+
+            // Act
+            var result = ItemReducer.OnSaveStoreFinished(_fixture.InitialState);
+
+            // Assert
+            result.Should().BeEquivalentTo(_fixture.ExpectedState);
+        }
+
+        private sealed class OnSaveStoreFinishedFixture : ItemReducerFixture
+        {
+            public void SetupInitialState()
+            {
+                InitialState = ExpectedState with
+                {
+                    Stores = ExpectedState.Stores with
+                    {
+                        Stores = new DomainTestBuilder<ItemStore>().CreateMany(2).ToList()
+                    }
+                };
+            }
+
+            public void SetupExpectedState()
+            {
+                ExpectedState = ExpectedState with
+                {
+                    Stores = new ActiveStores(new List<ItemStore>(0))
+                };
+            }
+        }
+    }
+
+    public class OnDeleteStoreFinished
+    {
+        private readonly OnDeleteStoreFinishedFixture _fixture = new();
+
+        [Fact]
+        public void OnDeleteStoreFinished_WithValidData_ShouldClearStores()
+        {
+            // Arrange
+            _fixture.SetupInitialState();
+            _fixture.SetupExpectedState();
+
+            // Act
+            var result = ItemReducer.OnDeleteStoreFinished(_fixture.InitialState);
+
+            // Assert
+            result.Should().BeEquivalentTo(_fixture.ExpectedState);
+        }
+
+        private sealed class OnDeleteStoreFinishedFixture : ItemReducerFixture
+        {
+            public void SetupInitialState()
+            {
+                InitialState = ExpectedState with
+                {
+                    Stores = ExpectedState.Stores with
+                    {
+                        Stores = new DomainTestBuilder<ItemStore>().CreateMany(2).ToList()
+                    }
+                };
+            }
+
+            public void SetupExpectedState()
+            {
+                ExpectedState = ExpectedState with
+                {
+                    Stores = new ActiveStores(new List<ItemStore>(0))
+                };
             }
         }
     }

--- a/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Effects/ShoppingListEffectsTests.cs
+++ b/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Effects/ShoppingListEffectsTests.cs
@@ -475,6 +475,74 @@ public class ShoppingListEffectsTests
         }
     }
 
+    public class HandleShoppingListEnteredAction
+    {
+        private readonly HandleShoppingListEnteredActionFixture _fixture = new();
+
+        [Fact]
+        public async Task HandleShoppingListEnteredAction_WithStateContainingNoStores_ShouldNotDoAnything()
+        {
+            // Arrange
+            _fixture.SetupStateContainingNoStores();
+            var queue = CallQueue.Create(_ => { });
+            var sut = _fixture.CreateSut();
+
+            // Act
+            await sut.HandleShoppingListEnteredAction(_fixture.DispatcherMock.Object);
+
+            // Assert
+            queue.VerifyOrder();
+        }
+
+        [Fact]
+        public async Task HandleShoppingListEnteredAction_WithStateContainingStores_ShouldDispatchStoreChangedAction()
+        {
+            // Arrange
+            _fixture.SetupStateContainingStores();
+            var queue = CallQueue.Create(_ =>
+            {
+                _fixture.SetupDispatchingStoreChangedAction();
+            });
+            var sut = _fixture.CreateSut();
+
+            // Act
+            await sut.HandleShoppingListEnteredAction(_fixture.DispatcherMock.Object);
+
+            // Assert
+            queue.VerifyOrder();
+        }
+
+        private sealed class HandleShoppingListEnteredActionFixture : ShoppingListEffectsFixture
+        {
+            public void SetupStateContainingNoStores()
+            {
+                State = State with
+                {
+                    Stores = State.Stores with
+                    {
+                        Stores = new List<ShoppingListStore>()
+                    }
+                };
+            }
+
+            public void SetupStateContainingStores()
+            {
+                State = State with
+                {
+                    Stores = State.Stores with
+                    {
+                        Stores = new DomainTestBuilder<ShoppingListStore>().CreateMany(2).ToList()
+                    }
+                };
+            }
+
+            public void SetupDispatchingStoreChangedAction()
+            {
+                SetupDispatchingAction(new SelectedStoreChangedAction(State.Stores.Stores.First().Id));
+            }
+        }
+    }
+
     public class HandleSelectedStoreChangedAction
     {
         private readonly HandleSelectedStoreChangedActionFixture _fixture = new();

--- a/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Effects/ShoppingListEffectsTests.cs
+++ b/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Effects/ShoppingListEffectsTests.cs
@@ -25,9 +25,25 @@ public class ShoppingListEffectsTests
         private readonly HandleLoadQuantityTypesActionFixture _fixture = new();
 
         [Fact]
+        public async Task HandleLoadQuantityTypesAction_WithQuantityTypesInState_ShouldNotDoAnything()
+        {
+            // Arrange
+            _fixture.SetupStateContainingQuantityTypes();
+            var queue = CallQueue.Create(_ => { });
+            var sut = _fixture.CreateSut();
+
+            // Act
+            await sut.HandleLoadQuantityTypesAction(_fixture.DispatcherMock.Object);
+
+            // Assert
+            queue.VerifyOrder();
+        }
+
+        [Fact]
         public async Task HandleLoadQuantityTypesAction_WithSuccessfulRequest_ShouldDispatchFinishedAction()
         {
             // Arrange
+            _fixture.SetupStateContainingNoQuantityTypes();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupExpectedQuantityTypes();
@@ -47,6 +63,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadQuantityTypesAction_WithWithApiException_ShouldCallEndpointAndDispatchActionInCorrectOrder()
         {
             // Arrange
+            _fixture.SetupStateContainingNoQuantityTypes();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupGettingQuantityTypesThrowsApiException();
@@ -65,6 +82,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadQuantityTypesAction_WithWithHttpException_ShouldCallEndpointAndDispatchActionInCorrectOrder()
         {
             // Arrange
+            _fixture.SetupStateContainingNoQuantityTypes();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupGettingQuantityTypesThrowsHttpRequestException();
@@ -114,6 +132,16 @@ public class ShoppingListEffectsTests
                 _expectedLoadFinishedAction = new LoadQuantityTypesFinishedAction(_expectedQuantityTypes);
                 SetupDispatchingAction(_expectedLoadFinishedAction);
             }
+
+            public void SetupStateContainingNoQuantityTypes()
+            {
+                State = State with { QuantityTypes = new List<QuantityType>() };
+            }
+
+            public void SetupStateContainingQuantityTypes()
+            {
+                State = State with { QuantityTypes = new List<QuantityType> { new DomainTestBuilder<QuantityType>().Create() } };
+            }
         }
     }
 
@@ -122,9 +150,25 @@ public class ShoppingListEffectsTests
         private readonly HandleLoadQuantityTypesInPacketActionFixture _fixture = new();
 
         [Fact]
+        public async Task HandleLoadQuantityTypesInPacketAction_WithQuantityTypesInState_ShouldNotDoAnything()
+        {
+            // Arrange
+            _fixture.SetupStateContainingQuantityTypesInPacket();
+            var queue = CallQueue.Create(_ => { });
+            var sut = _fixture.CreateSut();
+
+            // Act
+            await sut.HandleLoadQuantityTypesInPacketAction(_fixture.DispatcherMock.Object);
+
+            // Assert
+            queue.VerifyOrder();
+        }
+
+        [Fact]
         public async Task HandleLoadQuantityTypesInPacketAction_WithSuccessfulRequest_ShouldDispatchFinishedAction()
         {
             // Arrange
+            _fixture.SetupStateContainingNoQuantityTypesInPacket();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupExpectedQuantityTypesInPacket();
@@ -144,6 +188,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadQuantityTypesInPacketAction_WithWithApiException_ShouldCallEndpointAndDispatchActionInCorrectOrder()
         {
             // Arrange
+            _fixture.SetupStateContainingNoQuantityTypesInPacket();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupGettingQuantityTypesInPacketThrowsApiException();
@@ -162,6 +207,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadQuantityTypesInPacketAction_WithWithHttpException_ShouldCallEndpointAndDispatchActionInCorrectOrder()
         {
             // Arrange
+            _fixture.SetupStateContainingNoQuantityTypesInPacket();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupGettingQuantityTypesInPacketThrowsHttpRequestException();
@@ -211,6 +257,22 @@ public class ShoppingListEffectsTests
                 _expectedLoadFinishedAction = new LoadQuantityTypesInPacketFinishedAction(_expectedQuantityTypesInPacket);
                 SetupDispatchingAction(_expectedLoadFinishedAction);
             }
+
+            public void SetupStateContainingNoQuantityTypesInPacket()
+            {
+                State = State with { QuantityTypesInPacket = new List<QuantityTypeInPacket>() };
+            }
+
+            public void SetupStateContainingQuantityTypesInPacket()
+            {
+                State = State with
+                {
+                    QuantityTypesInPacket = new List<QuantityTypeInPacket>
+                    {
+                        new DomainTestBuilder<QuantityTypeInPacket>().Create()
+                    }
+                };
+            }
         }
     }
 
@@ -219,9 +281,25 @@ public class ShoppingListEffectsTests
         private readonly HandleLoadAllActiveStoresActionFixture _fixture = new();
 
         [Fact]
+        public async Task HandleLoadAllActiveStoresAction_WithStateContainingStores_ShouldNotDoAnything()
+        {
+            // Arrange
+            _fixture.SetupStateContainingStores();
+            var queue = CallQueue.Create(_ => { });
+            var sut = _fixture.CreateSut();
+
+            // Act
+            await sut.HandleLoadAllActiveStoresAction(_fixture.DispatcherMock.Object);
+
+            // Assert
+            queue.VerifyOrder();
+        }
+
+        [Fact]
         public async Task HandleLoadAllActiveStoresAction_WithoutStores_ShouldDispatchFinishedAction()
         {
             // Arrange
+            _fixture.SetupStateContainingNoStores();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupExpectedStoresEmpty();
@@ -241,6 +319,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadAllActiveStoresAction_WithoutStores_ShouldNotDispatchChangeAction()
         {
             // Arrange
+            _fixture.SetupStateContainingNoStores();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupExpectedStoresEmpty();
@@ -261,6 +340,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadAllActiveStoresAction_WithStores_ShouldCallEndpointAndDispatchActionInCorrectOrder()
         {
             // Arrange
+            _fixture.SetupStateContainingNoStores();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupExpectedStores();
@@ -281,6 +361,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadAllActiveStoresAction_WithApiException_ShouldDispatchExceptionNotificationAction()
         {
             // Arrange
+            _fixture.SetupStateContainingNoStores();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupExpectedStores();
@@ -300,6 +381,7 @@ public class ShoppingListEffectsTests
         public async Task HandleLoadAllActiveStoresAction_WithHttpRequestException_ShouldDispatchErrorNotificationAction()
         {
             // Arrange
+            _fixture.SetupStateContainingNoStores();
             var queue = CallQueue.Create(_ =>
             {
                 _fixture.SetupExpectedStores();
@@ -367,6 +449,28 @@ public class ShoppingListEffectsTests
 
                 _expectedLoadFinishedAction = new LoadAllActiveStoresFinishedAction(_expectedStoresForShoppingList);
                 SetupDispatchingAction(_expectedLoadFinishedAction);
+            }
+
+            public void SetupStateContainingNoStores()
+            {
+                State = State with
+                {
+                    Stores = State.Stores with
+                    {
+                        Stores = new List<ShoppingListStore>()
+                    }
+                };
+            }
+
+            public void SetupStateContainingStores()
+            {
+                State = State with
+                {
+                    Stores = State.Stores with
+                    {
+                        Stores = new DomainTestBuilder<ShoppingListStore>().CreateMany(2).ToList()
+                    }
+                };
             }
         }
     }
@@ -500,7 +604,6 @@ public class ShoppingListEffectsTests
             // Arrange
             var queue = CallQueue.Create(_ =>
             {
-                _fixture.SetupAction();
                 _fixture.SetupStoreId();
                 _fixture.SetupExpectedShoppingList();
                 _fixture.SetupGettingQuantityTypesInPacket();
@@ -521,7 +624,6 @@ public class ShoppingListEffectsTests
             // Arrange
             var queue = CallQueue.Create(_ =>
             {
-                _fixture.SetupAction();
                 _fixture.SetupStoreId();
                 _fixture.SetupGettingQuantityTypesInPacketThrowsApiException();
                 _fixture.SetupDispatchingExceptionNotificationAction();
@@ -541,7 +643,6 @@ public class ShoppingListEffectsTests
             // Arrange
             var queue = CallQueue.Create(_ =>
             {
-                _fixture.SetupAction();
                 _fixture.SetupStoreId();
                 _fixture.SetupGettingQuantityTypesInPacketThrowsHttpRequestException();
                 _fixture.SetupDispatchingLoadFromLocalStorageAction();
@@ -560,8 +661,6 @@ public class ShoppingListEffectsTests
             private readonly Guid _storeId = Guid.NewGuid();
             private ShoppingListModel? _expectedShoppingList;
             private LoadShoppingListFinishedAction? _expectedLoadFinishedAction;
-
-            public ReloadCurrentShoppingListAction? Action { get; private set; }
 
             public void SetupExpectedShoppingList()
             {
@@ -602,11 +701,6 @@ public class ShoppingListEffectsTests
             public void SetupDispatchingLoadFromLocalStorageAction()
             {
                 SetupDispatchingAction(new LoadShoppingListFromLocalStorageAction(_storeId));
-            }
-
-            public void SetupAction()
-            {
-                Action = new ReloadCurrentShoppingListAction();
             }
         }
     }

--- a/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Reducers/ShoppingListReducerTests.cs
+++ b/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Reducers/ShoppingListReducerTests.cs
@@ -50,12 +50,6 @@ public class ShoppingListReducerTests
             {
                 ExpectedState = ExpectedState with
                 {
-                    QuantityTypes = new List<QuantityType>(),
-                    QuantityTypesInPacket = new List<QuantityTypeInPacket>(),
-                    Stores = ExpectedState.Stores with
-                    {
-                        Stores = new List<ShoppingListStore>()
-                    },
                     SelectedStoreId = Guid.Empty,
                     ItemsInBasketVisible = true,
                     EditModeActive = false,

--- a/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Reducers/ShoppingListReducerTests.cs
+++ b/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Reducers/ShoppingListReducerTests.cs
@@ -13,12 +13,7 @@ public class ShoppingListReducerTests
 {
     public class OnShoppingListEntered
     {
-        private readonly OnShoppingListEnteredFixture _fixture;
-
-        public OnShoppingListEntered()
-        {
-            _fixture = new OnShoppingListEnteredFixture();
-        }
+        private readonly OnShoppingListEnteredFixture _fixture = new();
 
         [Fact]
         public void OnShoppingListEntered_WithValidData_ShouldResetState()
@@ -77,12 +72,7 @@ public class ShoppingListReducerTests
 
     public class OnLoadQuantityTypesFinished
     {
-        private readonly OnLoadQuantityTypesFinishedFixture _fixture;
-
-        public OnLoadQuantityTypesFinished()
-        {
-            _fixture = new OnLoadQuantityTypesFinishedFixture();
-        }
+        private readonly OnLoadQuantityTypesFinishedFixture _fixture = new();
 
         [Fact]
         public void OnLoadQuantityTypesFinished_WithValidData_ShouldSetQuantityTypes()
@@ -121,12 +111,7 @@ public class ShoppingListReducerTests
 
     public class OnLoadQuantityTypesInPacketFinished
     {
-        private readonly OnLoadQuantityTypesInPacketFinishedFixture _fixture;
-
-        public OnLoadQuantityTypesInPacketFinished()
-        {
-            _fixture = new OnLoadQuantityTypesInPacketFinishedFixture();
-        }
+        private readonly OnLoadQuantityTypesInPacketFinishedFixture _fixture = new();
 
         [Fact]
         public void OnLoadQuantityTypesInPacketFinished_WithValidData_ShouldSetQuantityTypesInPacket()
@@ -165,12 +150,7 @@ public class ShoppingListReducerTests
 
     public class OnLoadAllActiveStoresFinished
     {
-        private readonly OnLoadAllActiveStoresFinishedFixture _fixture;
-
-        public OnLoadAllActiveStoresFinished()
-        {
-            _fixture = new OnLoadAllActiveStoresFinishedFixture();
-        }
+        private readonly OnLoadAllActiveStoresFinishedFixture _fixture = new();
 
         [Fact]
         public void OnLoadAllActiveStoresFinished_WithValidData_ShouldSetAndOrderStores()
@@ -232,12 +212,7 @@ public class ShoppingListReducerTests
 
     public class OnSelectedStoreChanged
     {
-        private readonly OnSelectedStoreChangedFixture _fixture;
-
-        public OnSelectedStoreChanged()
-        {
-            _fixture = new OnSelectedStoreChangedFixture();
-        }
+        private readonly OnSelectedStoreChangedFixture _fixture = new();
 
         [Fact]
         public void OnSelectedStoreChanged_WithValidData_ShouldSetSelectedStoreId()
@@ -294,12 +269,7 @@ public class ShoppingListReducerTests
 
     public class OnLoadShoppingListFinished
     {
-        private readonly OnLoadShoppingListFinishedFixture _fixture;
-
-        public OnLoadShoppingListFinished()
-        {
-            _fixture = new OnLoadShoppingListFinishedFixture();
-        }
+        private readonly OnLoadShoppingListFinishedFixture _fixture = new();
 
         [Fact]
         public void OnLoadShoppingListFinished_WithEditModeActive_WithItemsInBasketNotVisible_ShouldResetToDefaultsAndSetShoppingList()
@@ -350,12 +320,7 @@ public class ShoppingListReducerTests
 
     public class OnToggleItemsInBasketVisible
     {
-        private readonly OnToggleItemsInBasketVisibleFixture _fixture;
-
-        public OnToggleItemsInBasketVisible()
-        {
-            _fixture = new OnToggleItemsInBasketVisibleFixture();
-        }
+        private readonly OnToggleItemsInBasketVisibleFixture _fixture = new();
 
         [Fact]
         public void OnToggleItemsInBasketVisible_WithItemsInBasketVisible_ShouldSetToNotVisible()
@@ -423,12 +388,7 @@ public class ShoppingListReducerTests
 
     public class OnToggleEditMode
     {
-        private readonly OnToggleEditModeFixture _fixture;
-
-        public OnToggleEditMode()
-        {
-            _fixture = new OnToggleEditModeFixture();
-        }
+        private readonly OnToggleEditModeFixture _fixture = new();
 
         [Fact]
         public void OnToggleEditMode_WithEditModeActive_ShouldSetToInactive()
@@ -496,12 +456,7 @@ public class ShoppingListReducerTests
 
     public class OnToggleShoppingListSectionExpansion
     {
-        private readonly OnToggleShoppingListSectionExpansionFixture _fixture;
-
-        public OnToggleShoppingListSectionExpansion()
-        {
-            _fixture = new OnToggleShoppingListSectionExpansionFixture();
-        }
+        private readonly OnToggleShoppingListSectionExpansionFixture _fixture = new();
 
         [Fact]
         public void OnToggleShoppingListSectionExpansion_WithSectionExpanded_ShouldCollapseSection()
@@ -656,6 +611,88 @@ public class ShoppingListReducerTests
             public void SetupRandomAction()
             {
                 Action = new ToggleShoppingListSectionExpansionAction(Guid.NewGuid());
+            }
+        }
+    }
+
+    public class OnSaveStoreFinished
+    {
+        private readonly OnSaveStoreFinishedFixture _fixture = new();
+
+        [Fact]
+        public void OnSaveStoreFinished_WithValidData_ShouldClearStores()
+        {
+            // Arrange
+            _fixture.SetupInitialState();
+            _fixture.SetupExpectedState();
+
+            // Act
+            var result = ShoppingListReducer.OnSaveStoreFinished(_fixture.InitialState);
+
+            // Assert
+            result.Should().BeEquivalentTo(_fixture.ExpectedState);
+        }
+
+        private sealed class OnSaveStoreFinishedFixture : ShoppingListReducerFixture
+        {
+            public void SetupInitialState()
+            {
+                InitialState = ExpectedState with
+                {
+                    Stores = ExpectedState.Stores with
+                    {
+                        Stores = new DomainTestBuilder<ShoppingListStore>().CreateMany(2).ToList()
+                    }
+                };
+            }
+
+            public void SetupExpectedState()
+            {
+                ExpectedState = ExpectedState with
+                {
+                    Stores = new AllActiveStores(new List<ShoppingListStore>(0))
+                };
+            }
+        }
+    }
+
+    public class OnDeleteStoreFinished
+    {
+        private readonly OnDeleteStoreFinishedFixture _fixture = new();
+
+        [Fact]
+        public void OnDeleteStoreFinished_WithValidData_ShouldClearStores()
+        {
+            // Arrange
+            _fixture.SetupInitialState();
+            _fixture.SetupExpectedState();
+
+            // Act
+            var result = ShoppingListReducer.OnDeleteStoreFinished(_fixture.InitialState);
+
+            // Assert
+            result.Should().BeEquivalentTo(_fixture.ExpectedState);
+        }
+
+        private sealed class OnDeleteStoreFinishedFixture : ShoppingListReducerFixture
+        {
+            public void SetupInitialState()
+            {
+                InitialState = ExpectedState with
+                {
+                    Stores = ExpectedState.Stores with
+                    {
+                        Stores = new DomainTestBuilder<ShoppingListStore>().CreateMany(2).ToList()
+                    }
+                };
+            }
+
+            public void SetupExpectedState()
+            {
+                ExpectedState = ExpectedState with
+                {
+                    Stores = new AllActiveStores(new List<ShoppingListStore>(0))
+                };
             }
         }
     }

--- a/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Reducers/ShoppingListReducerTests.cs
+++ b/Frontend/ShoppingList.Frontend.Redux.Tests/ShoppingLists/Reducers/ShoppingListReducerTests.cs
@@ -35,9 +35,6 @@ public class ShoppingListReducerTests
             {
                 InitialState = ExpectedState with
                 {
-                    QuantityTypes = new DomainTestBuilder<QuantityType>().CreateMany(2).ToList(),
-                    QuantityTypesInPacket = new DomainTestBuilder<QuantityTypeInPacket>().CreateMany(2).ToList(),
-                    Stores = new AllActiveStores(new DomainTestBuilder<ShoppingListStore>().CreateMany(2).ToList()),
                     SelectedStoreId = Guid.NewGuid(),
                     ItemsInBasketVisible = false,
                     EditModeActive = true,

--- a/Frontend/ShoppingList.Frontend.Redux/Items/Reducers/ItemReducer.cs
+++ b/Frontend/ShoppingList.Frontend.Redux/Items/Reducers/ItemReducer.cs
@@ -2,6 +2,7 @@
 using ProjectHermes.ShoppingList.Frontend.Redux.Items.Actions;
 using ProjectHermes.ShoppingList.Frontend.Redux.Items.Actions.Search;
 using ProjectHermes.ShoppingList.Frontend.Redux.Items.States;
+using ProjectHermes.ShoppingList.Frontend.Redux.Stores.Actions.Editor;
 
 namespace ProjectHermes.ShoppingList.Frontend.Redux.Items.Reducers;
 
@@ -50,5 +51,28 @@ public static class ItemReducer
     public static ItemState OnLoadActiveStoresFinished(ItemState state, LoadActiveStoresFinishedAction action)
     {
         return state with { Stores = action.Stores };
+    }
+
+    [ReducerMethod(typeof(SaveStoreFinishedAction))]
+    public static ItemState OnSaveStoreFinished(ItemState state)
+    {
+        return ClearStores(state);
+    }
+
+    [ReducerMethod(typeof(DeleteStoreFinishedAction))]
+    public static ItemState OnDeleteStoreFinished(ItemState state)
+    {
+        return ClearStores(state);
+    }
+
+    private static ItemState ClearStores(ItemState state)
+    {
+        return state with
+        {
+            Stores = state.Stores with
+            {
+                Stores = new List<ItemStore>(0)
+            }
+        };
     }
 }

--- a/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Effects/ShoppingListEffects.cs
+++ b/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Effects/ShoppingListEffects.cs
@@ -35,6 +35,9 @@ public class ShoppingListEffects
     [EffectMethod(typeof(LoadQuantityTypesAction))]
     public async Task HandleLoadQuantityTypesAction(IDispatcher dispatcher)
     {
+        if (_state.Value.QuantityTypes.Any())
+            return;
+
         IEnumerable<QuantityType> quantityTypes;
         try
         {
@@ -56,6 +59,9 @@ public class ShoppingListEffects
     [EffectMethod(typeof(LoadQuantityTypesInPacketAction))]
     public async Task HandleLoadQuantityTypesInPacketAction(IDispatcher dispatcher)
     {
+        if (_state.Value.QuantityTypesInPacket.Any())
+            return;
+
         IEnumerable<QuantityTypeInPacket> quantityTypes;
         try
         {
@@ -77,6 +83,9 @@ public class ShoppingListEffects
     [EffectMethod(typeof(LoadAllActiveStoresAction))]
     public async Task HandleLoadAllActiveStoresAction(IDispatcher dispatcher)
     {
+        if (_state.Value.Stores.Stores.Any())
+            return;
+
         List<ShoppingListStore> stores;
         try
         {

--- a/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Effects/ShoppingListEffects.cs
+++ b/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Effects/ShoppingListEffects.cs
@@ -109,6 +109,19 @@ public class ShoppingListEffects
             dispatcher.Dispatch(new SelectedStoreChangedAction(stores.First().Id));
     }
 
+    [EffectMethod(typeof(ShoppingListEnteredAction))]
+    public Task HandleShoppingListEnteredAction(IDispatcher dispatcher)
+    {
+        if (!_state.Value.Stores.Stores.Any())
+            return Task.CompletedTask;
+
+        var store = _state.Value.Stores.Stores.First();
+
+        dispatcher.Dispatch(new SelectedStoreChangedAction(store.Id));
+
+        return Task.CompletedTask;
+    }
+
     [EffectMethod]
     public async Task HandleSelectedStoreChangedAction(SelectedStoreChangedAction action, IDispatcher dispatcher)
     {

--- a/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Reducers/ShoppingListReducer.cs
+++ b/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Reducers/ShoppingListReducer.cs
@@ -3,6 +3,7 @@ using ProjectHermes.ShoppingList.Frontend.Redux.Shared.States;
 using ProjectHermes.ShoppingList.Frontend.Redux.ShoppingList.Actions;
 using ProjectHermes.ShoppingList.Frontend.Redux.ShoppingList.States;
 using ProjectHermes.ShoppingList.Frontend.Redux.ShoppingList.States.Comparer;
+using ProjectHermes.ShoppingList.Frontend.Redux.Stores.Actions.Editor;
 
 namespace ProjectHermes.ShoppingList.Frontend.Redux.ShoppingList.Reducers;
 
@@ -114,6 +115,29 @@ public static class ShoppingListReducer
             ShoppingList = state.ShoppingList with
             {
                 Sections = new SortedSet<ShoppingListSection>(sections, new SortingIndexComparer())
+            }
+        };
+    }
+
+    [ReducerMethod(typeof(SaveStoreFinishedAction))]
+    public static ShoppingListState OnSaveStoreFinished(ShoppingListState state)
+    {
+        return ClearStores(state);
+    }
+
+    [ReducerMethod(typeof(DeleteStoreFinishedAction))]
+    public static ShoppingListState OnDeleteStoreFinished(ShoppingListState state)
+    {
+        return ClearStores(state);
+    }
+
+    private static ShoppingListState ClearStores(ShoppingListState state)
+    {
+        return state with
+        {
+            Stores = state.Stores with
+            {
+                Stores = new List<ShoppingListStore>(0)
             }
         };
     }

--- a/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Reducers/ShoppingListReducer.cs
+++ b/Frontend/ShoppingList.Frontend.Redux/ShoppingList/Reducers/ShoppingListReducer.cs
@@ -1,5 +1,4 @@
 ﻿using Fluxor;
-using ProjectHermes.ShoppingList.Frontend.Redux.Shared.States;
 using ProjectHermes.ShoppingList.Frontend.Redux.ShoppingList.Actions;
 using ProjectHermes.ShoppingList.Frontend.Redux.ShoppingList.States;
 using ProjectHermes.ShoppingList.Frontend.Redux.ShoppingList.States.Comparer;
@@ -14,12 +13,6 @@ public static class ShoppingListReducer
     {
         return state with
         {
-            QuantityTypes = new List<QuantityType>(),
-            QuantityTypesInPacket = new List<QuantityTypeInPacket>(),
-            Stores = state.Stores with
-            {
-                Stores = new List<ShoppingListStore>()
-            },
             SelectedStoreId = Guid.Empty,
             ItemsInBasketVisible = true,
             EditModeActive = false,


### PR DESCRIPTION
closes #428

This PR also reduces the amount of network calls the shopping list page makes when the user is re-entering it.